### PR TITLE
Use function expressions to avoid hoisting behavior

### DIFF
--- a/lib/u2f-api.js
+++ b/lib/u2f-api.js
@@ -196,9 +196,10 @@ function register( registerRequests, signRequests /* = null */, timeout )
 
 		return new Promise( function( resolve, reject )
 		{
+			var cb;
 			if ( native )
 			{
-				function cb( response )
+				cb = function( response )
 				{
 					if ( response.errorCode )
 						reject( makeError( "Registration failed", response ) );
@@ -216,7 +217,7 @@ function register( registerRequests, signRequests /* = null */, timeout )
 			}
 			else
 			{
-				function cb( err, response )
+				cb = function( err, response )
 				{
 					if ( err )
 						reject( err );
@@ -248,9 +249,10 @@ function sign( signRequests, timeout )
 
 		return new Promise( function( resolve, reject )
 		{
+			var cb;
 			if ( native )
 			{
-				function cb( response )
+				cb = function( response )
 				{
 					if ( response.errorCode )
 						reject( makeError( "Sign failed", response ) );
@@ -268,7 +270,7 @@ function sign( signRequests, timeout )
 			}
 			else
 			{
-				function cb( err, response )
+				cb = function( err, response )
 				{
 					if ( err )
 						reject( err );


### PR DESCRIPTION
This commit changes `function cb` to `cb = function()` so that hosting
of functions does not change behavior.  At least with uglifyjs the
functions from both branches are hosted to the top of the function
under the same name which causes the callback from the non native
branch to be used in the native branch.

This is what is currently being transpiled:

```
function d(e, t) {
    var a = this;
    return Array.isArray(e) || (e = [ e ]), s(a, n(a).then(function(n) {
        l(n);
        var r = n.native, s = n.u2f;
        return new a(function(a, n) {
            function o(e) {
                e.errorCode ? n(i("Sign failed", e)) : (delete e.errorCode, a(e));
            }
            function o(e, t) {
                e ? n(e) : t.errorCode ? n(i("Sign failed", t)) : a(t);
            }
            if (r) {
                var l = e[0].appId, c = e[0].challenge;
                s.sign(l, c, e, o, t);
            } else s.sign(e, o, t);
        });
    })).promise;
}
```

Which is obviously incorrect.