### PR TITLE
Update safari user agent version parsing

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -253,14 +253,14 @@ describe( 'general', ( ) =>
 	} ) );
 
 	it( 'isSupported should be false for Safari 10',
-		wrappedTest( { userAgent: "Safari/10" }, async api =>
+		wrappedTest( { userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) Version/10.0.3 Safari/602.4.8" }, async api =>
 	{
 		const supported = await api.isSupported( );
 		expect( supported ).toBe( false );
 	} ) );
 
 	it( 'isSupported should be true for Safari 13',
-		wrappedTest( { userAgent: "Safari/13" }, async api =>
+		wrappedTest( { userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15" }, async api =>
 	{
 		const supported = await api.isSupported( );
 		expect( supported ).toBe( true );

--- a/lib/u2f-api.ts
+++ b/lib/u2f-api.ts
@@ -39,9 +39,9 @@ const isBrowser =
 const isSafari = isBrowser
 	&& navigator.userAgent.match( /Safari\// )
 	&& !navigator.userAgent.match( /Chrome\// );
-const isSupportedSafari = isBrowser
-	&& navigator.userAgent.match( /Safari\/(1[3456789])/ )
-	&& !navigator.userAgent.match( /Chrome\// );
+const isSupportedSafari = isSafari
+	&& navigator.userAgent.match( /Version\/(1[3456789])/ )
+
 const isEDGE = isBrowser && /(Edge\/)|(edg\/)/i.test(navigator.userAgent);
 const isIE = isBrowser && /(MSIE 9|MSIE 10|rv:11.0)/i.test(navigator.userAgent);
 


### PR DESCRIPTION
Safari formats the version slightly different than how the regex is currently checking for it. This change fixes that and verifies with tests from full safari user agent strings.